### PR TITLE
Implement RSVP form and env generator

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,60 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [name, setName] = useState('')
+  const [attendance, setAttendance] = useState('yes')
+  const [allergy, setAllergy] = useState('')
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setMessage('')
+    setError('')
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/rsvp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, attendance, allergy })
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setMessage('ありがとうございます！')
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div>
+      <h1>RSVP</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>
+            お名前
+            <input value={name} onChange={e => setName(e.target.value)} required />
+          </label>
+        </div>
+        <div>
+          <label>
+            出席
+            <select value={attendance} onChange={e => setAttendance(e.target.value)}>
+              <option value="yes">はい</option>
+              <option value="no">いいえ</option>
+            </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            アレルギー
+            <textarea value={allergy} onChange={e => setAllergy(e.target.value)} />
+          </label>
+        </div>
+        <button type="submit">送信</button>
+      </form>
+      {message && <p>{message}</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
   )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "infra"
       ],
       "devDependencies": {
-        "aws-cdk": "^2"
+        "aws-cdk": "^2",
+        "dotenv": "^17.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -164,6 +165,7 @@
     "infra": {
       "version": "0.1.0",
       "dependencies": {
+        "@aws-cdk/aws-s3-deployment": "^1.203.0",
         "@aws-sdk/client-dynamodb": "^3.840.0",
         "aws-cdk-lib": "2.202.0",
         "constructs": "^10.0.0"
@@ -208,6 +210,1220 @@
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "license": "Apache-2.0"
     },
+    "node_modules/@aws-cdk/assets": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.203.0.tgz",
+      "integrity": "sha512-aEexr1PEZPqTcBXiKLwmiWYtpoC6vPpsGAqe39U6lovXP675qO6/VTpE26AUtS0sDkuhCBnXDQR5H49e0+A+jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/assets/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-acmpca": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-acmpca/-/aws-acmpca-1.203.0.tgz",
+      "integrity": "sha512-0+7de1E0JxTjPe8pm73Io3WAEC9pvEjdKmNYwXApYCslqlFqBOuHjU9pQh++6cYcUWCMmav1iwM9zqCB6ZVRSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-acmpca/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-applicationautoscaling": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.203.0.tgz",
+      "integrity": "sha512-tz/BzZ++hd+T5s4AQo4l7fKaK6+xeGEbR7fGulgz8xByW5V46/krXvpTWVvM7VV2WSigVx1QeS9vcT3MOdsYBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-autoscaling-common": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-autoscaling-common": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-applicationautoscaling/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-autoscaling-common": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.203.0.tgz",
+      "integrity": "sha512-ET3whArynAzRMxrnlkgAdWWzdaRg2QJWcepjSr615pwF0cOFjTW2scpPWIpcaugN2z+wFPlylP5zloA16FM0Tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-autoscaling-common/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-certificatemanager": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.203.0.tgz",
+      "integrity": "sha512-P/xgE5oF623T9NIlTRfTwX6zR41ae2C+YAVOpGlI4X8ZnjB219LGZd7VhAIu6A6qv38ZQE2erYaXHe39nIFEFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-acmpca": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-route53": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-acmpca": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-route53": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-certificatemanager/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudformation": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.203.0.tgz",
+      "integrity": "sha512-vwNrk5KT0TgIKy+hinjWu/CBEet394mK8o2eFzQG5G82An0O3n/ILdaBrXZut0tyHxJSYQ90+Zaor6Ndld49jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-sns": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-sns": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudformation/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudfront": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.203.0.tgz",
+      "integrity": "sha512-BdSCRoQ0CWT8U5Mhog80+sENG8bReXqhyzu8fyRLwT4EvCNmDEYVjotG7xbzgobRYKL0zhMMvNAtVZ3I1iw0fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-certificatemanager": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-ssm": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-certificatemanager": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-ssm": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudfront/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudwatch": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.203.0.tgz",
+      "integrity": "sha512-RJfUHAtCPefcgWlH6Nqcv0f1svPfxbESUC52tK6yKqhmzo+57ePLkONsn88x22TuWo/hXOpjxYqrUECr0S5YqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudwatch/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codeguruprofiler": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.203.0.tgz",
+      "integrity": "sha512-Tl9DGRY/BN615J8H4SUQxQ0Zb2TzkaBYHFx4F1lt4NYdWHYh6oALxLEBSkXD5txPvvtH4MouDENuqMBV/fZI3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codeguruprofiler/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codestarnotifications": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.203.0.tgz",
+      "integrity": "sha512-Qd3iJiFx5Nt+rZRNnmMUmknNetq4069pUhOTv0NTxB+ZmWQ1leQ4iSrhQ5YOANWBK0+EtPMz9YBjKjE4zBPf+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codestarnotifications/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ec2": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.203.0.tgz",
+      "integrity": "sha512-6Q/kvAKsprESeGCYMYS9KiChDyhzMk6NerSreVD83UbcvUJU9EjGUJF+HJfRQXn66YjdOsXKcm89Ni31ftP5PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/aws-ssm": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/aws-ssm": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ec2/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
+      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ec2/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ec2/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ec2/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ec2/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/aws-ec2/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.203.0.tgz",
+      "integrity": "sha512-pMijGTZzncb10zJLuqDzFtHpVxpK2dQdD/1Md7FYF1Mm7/r2CFx4Q2H3f1fOi4sBXk3ftypV8X7HFzIrWPwCSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr-assets": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.203.0.tgz",
+      "integrity": "sha512-wPAjllyLs+TvdakhwATjIyc5mBuNJFurPM2S1mo7YC4fURp2NOb9vHpIFgV9ZC+r8xadBFWt13de72cyl+h2iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/assets": "1.203.0",
+        "@aws-cdk/aws-ecr": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/assets": "1.203.0",
+        "@aws-cdk/aws-ecr": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr-assets/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-efs": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.203.0.tgz",
+      "integrity": "sha512-JYy8N7GwKCXjFpsBZZqy9VbS/zJGDSq8etXAvBsrscDveDzzQr4/6CiXYU70aL5lLV34ex07A5lKBmII9cqq0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-efs/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
+      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-efs/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/aws-efs/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-efs/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-efs/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/aws-efs/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-events": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.203.0.tgz",
+      "integrity": "sha512-LYjKGqqosXG3HLAmvSAS/N5OSxH0uqHmDlisapwl4kEBPfSOvzzVF9TTuMulDYfSBV0Esspb3RIkXc/ja7f9JQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-events/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-iam": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.203.0.tgz",
+      "integrity": "sha512-8qXLtOzkaLlk7WlssocExMYruOb59irhspTvHvf/kpcMBmWQoyNRC80Ab3QtXkZNBppfrMkROGZvqzW2GlxAwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-iam/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kms": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.203.0.tgz",
+      "integrity": "sha512-TlG5Td7pRrgo5xta0ePIp6x6+4uq0P+1K3tQtpjEFbD2E21krujXdWNdHmuvRoNsY5NbLhOCF5g6PNCdJdvLJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kms/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
+      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kms/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kms/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kms/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kms/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/aws-kms/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-lambda": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.203.0.tgz",
+      "integrity": "sha512-O88yvNpxi4tcizHhwRkGfEBg+WDoagxgwr2TUNFWkKQVEaL/by9BeZk84LNXLC6OO5WrnC+0qgSz1KHyDXMrqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-ecr": "1.203.0",
+        "@aws-cdk/aws-ecr-assets": "1.203.0",
+        "@aws-cdk/aws-efs": "1.203.0",
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/aws-signer": "1.203.0",
+        "@aws-cdk/aws-sns": "1.203.0",
+        "@aws-cdk/aws-sqs": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-ecr": "1.203.0",
+        "@aws-cdk/aws-ecr-assets": "1.203.0",
+        "@aws-cdk/aws-efs": "1.203.0",
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/aws-signer": "1.203.0",
+        "@aws-cdk/aws-sns": "1.203.0",
+        "@aws-cdk/aws-sqs": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-lambda/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-logs": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.203.0.tgz",
+      "integrity": "sha512-I5/0+NuPdTRSq0cK8W1w8hHyGGj4mqTXFou0sHed3BUN4zYim2cB88uosOVMOhkpGRr19+FEwEThvyntRLcTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-logs/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.203.0.tgz",
+      "integrity": "sha512-u2lvS15JtZURBxK8SCMBcUaNOiBhHfWThk6wm7GfkoaSFsgdDnM/siePEHv8aau1PkRnXX4esy6RQGwIUohyfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/custom-resources": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/custom-resources": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
+      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/aws-route53/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.203.0.tgz",
+      "integrity": "sha512-xPxCv7l6zh7nGoFwLNzHmP07ULtWx/ubDE6l2ZqkRF4ZHVWoyTk7zVs4Q+BmRM1mUn0yDHyMTKKf887lQu9eVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3-assets": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.203.0.tgz",
+      "integrity": "sha512-BXvIWRdHmwNkpDbQXsB0hZWGJ3szB264Dq14CzWu6+6J8beaUNrT+1/z1mglr6S3UraHMsOhhSO48zT9k+MzhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/assets": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/assets": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3-assets/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3-deployment": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.203.0.tgz",
+      "integrity": "sha512-LnxeOjzK1LpaZ+iwTeg9pBPkH9yDp7qKT52PesM/ZFZt+7Dj+EX8onqsgmbBRzV09CgYsG/XFPx06vRJvhNuJg==",
+      "bundleDependencies": [
+        "case"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-cloudfront": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-efs": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/lambda-layer-awscli": "1.203.0",
+        "case": "1.6.3",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudfront": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-efs": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-s3": "1.203.0",
+        "@aws-cdk/aws-s3-assets": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/lambda-layer-awscli": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3-deployment/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3-deployment/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-signer": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.203.0.tgz",
+      "integrity": "sha512-czHs8DIIA2wxYW2iFTEWAVydFURMvyZO+rtv7V4LXV9G18qRdBVxyx7VU2Lhr8nd5sg+uPV4Vonjt8OvUfO12A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-signer/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sns": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.203.0.tgz",
+      "integrity": "sha512-9HBgItNq7zM+ElEUEnomHjAgYsZWOjHaafv1x+Gbk/UH4xKzoM7t6kdlRa0qCVeyWhaClGCyRAJtOP42UiGmSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-codestarnotifications": "1.203.0",
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-sqs": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-codestarnotifications": "1.203.0",
+        "@aws-cdk/aws-events": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/aws-sqs": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sns/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sqs": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.203.0.tgz",
+      "integrity": "sha512-GDSWc/O9HcxjP4pbCYuZjqE2GXymzvv6rM8Q17NtERACpUMf/eAuNITLCulE1Y6ufE9A9/lgkT96I3QLd9HBNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sqs/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ssm": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.203.0.tgz",
+      "integrity": "sha512-zR/eLVPO+O3MMbnMgWSLybrj7VxIt1d90QPHPZMV92hYdzWDKBfVZ09P82muNILRF+SMcK7TrFLCDi5Nos0S2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-kms": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ssm/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
+      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ssm/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ssm/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ssm/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ssm/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/aws-ssm/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
       "version": "44.9.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-44.9.0.tgz",
@@ -242,6 +1458,369 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/core": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.203.0.tgz",
+      "integrity": "sha512-3/quPwnGWKHm/Bzna/du5WP5a/Wp/NYqDyL1rJ1A3EPpsRQYywJPj77+M8nG5sD5qNIoFbhN7Q5aee+bcS7GGA==",
+      "bundleDependencies": [
+        "fs-extra",
+        "minimatch",
+        "@balena/dockerignore",
+        "ignore"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "@balena/dockerignore": "^1.0.2",
+        "constructs": "^3.3.69",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.4",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/region-info": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
+      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/core/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/core/node_modules/at-least-node": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-cdk/core/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-cdk/core/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/core/node_modules/ignore": {
+      "version": "5.2.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/universalify": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/custom-resources": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.203.0.tgz",
+      "integrity": "sha512-JpUH3d5gG/2MrWCbnFC96FgRGUqcecY84xZHsfTKUlPQ2bUzElHih2tvbR21DQ5ZIKvFznol3DheduDSD/TgpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-cloudformation": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-sns": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudformation": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.203.0",
+        "@aws-cdk/aws-iam": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/aws-logs": "1.203.0",
+        "@aws-cdk/aws-sns": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/custom-resources/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.203.0.tgz",
+      "integrity": "sha512-W2flnJFGytifPw2ojEsh9l8MAI4UANaUcMKr+qt4eJmFwrtVcS7nasdJQGSatQdxkAwd2pX4x10brAHYoAqjjQ==",
+      "bundleDependencies": [
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": "1.203.0"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
+      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/lambda-layer-awscli": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.203.0.tgz",
+      "integrity": "sha512-xA4kO8yl2Q5IjfKvIJvltTXhjEkQVS8lOSsdMIEODkaq7BtttKpxM/dU4LPky5se1nGUttNiJzPKgaXYUHa+4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-lambda": "1.203.0",
+        "@aws-cdk/core": "1.203.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-awscli/node_modules/constructs": {
+      "version": "3.4.344",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.344.tgz",
+      "integrity": "sha512-Qq3upn44oGdvgasHUKWVFsrynyYrtVRd9fd8ko9cJOrFzx9eCm3iI4bhBryQqaISdausbTYUOXmoEe/YSJ16Nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-cdk/region-info": {
+      "version": "1.203.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.203.0.tgz",
+      "integrity": "sha512-3GzFYrdUO2NGcOrlIJ1TvjRxB0/ntBEyQgwFtVJQSvt3msCznE/w1n6pZS+oDF12NWtIPFbsJ5zTGdJ+PLMJhg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 14.15.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -4614,7 +6193,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bowser": {
@@ -4627,7 +6205,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4858,7 +6435,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -5003,6 +6579,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.1.tgz",
+      "integrity": "sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ejs": {
@@ -5754,7 +7343,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6907,7 +8495,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7581,7 +9168,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "infra"
   ],
   "devDependencies": {
-    "aws-cdk": "^2"
+    "aws-cdk": "^2",
+    "dotenv": "^17.0.1"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/generate-env.mjs
+++ b/scripts/generate-env.mjs
@@ -1,0 +1,22 @@
+import { spawn } from 'child_process'
+import { promises as fs } from 'fs'
+
+async function run() {
+  await new Promise((resolve, reject) => {
+    const p = spawn('cdk', ['--outputs-file', 'cdk-outputs.json'], { stdio: 'inherit' })
+    p.on('close', code => code === 0 ? resolve() : reject(new Error(`cdk exited with ${code}`)))
+  })
+  const data = JSON.parse(await fs.readFile('cdk-outputs.json', 'utf8'))
+  let apiUrl
+  for (const stack of Object.values(data)) {
+    if (stack.HttpApiUrl) {
+      apiUrl = stack.HttpApiUrl
+      break
+    }
+  }
+  if (!apiUrl) throw new Error('HttpApiUrl not found')
+  await fs.writeFile('frontend/.env.local', `VITE_API_URL=${apiUrl}\n`)
+  console.log('frontend/.env.local generated')
+}
+
+run().catch(err => { console.error(err); process.exit(1) })


### PR DESCRIPTION
## Summary
- add RSVP form with API call
- define VITE_API_URL template file
- generate .env.local from CDK outputs
- include dotenv as a dev dependency

## Testing
- `npm test -w infra`
- `npm run lint -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_6866404e7cf8833186f53df167817009