### PR TITLE
Add pre-wedding photo gallery

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import './App.css'
 import HeaderBanner from './components/HeaderBanner'
 import InvitationContent from './components/InvitationContent'
+import PreWeddingPhotos from './components/PreWeddingPhotos'
 import RSVPForm, { type RSVPFormData } from './components/RSVPForm'
 import { cn } from './lib/utils'
 
@@ -64,6 +65,9 @@ function App() {
             <div className="space-y-8">
               <section aria-label="Wedding invitation details">
                 <InvitationContent />
+              </section>
+              <section aria-label="Pre wedding photos">
+                <PreWeddingPhotos />
               </section>
               <section aria-label="RSVP form">
                 <RSVPForm onSubmit={handleRSVPSubmit} status={rsvpStatus} />

--- a/frontend/src/components/PreWeddingPhotos.tsx
+++ b/frontend/src/components/PreWeddingPhotos.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { cn } from "../lib/utils";
+
+export default function PreWeddingPhotos() {
+  const photos = [
+    "/1752327445417.jpg",
+    "/1752327458289.jpg",
+    "/1752327461784.jpg",
+  ];
+
+  return (
+    <section
+      className={cn(
+        "border-4 border-double border-yellow-600 p-4 rounded-lg",
+        "bg-white/80 space-y-4",
+        "font-['Times_New_Roman',_serif]"
+      )}
+      style={{
+        boxShadow: `inset 0 0 10px rgba(0,0,0,0.4), 0 0 10px rgba(0,0,0,0.5)`,
+      }}
+    >
+      <h2
+        className="text-xl text-center font-bold text-yellow-800"
+        style={{ textShadow: "2px 2px 0 #FFF8DC" }}
+      >
+        📸 前撮り写真 📸
+      </h2>
+      <div className="flex justify-center space-x-2">
+        {photos.map((src, i) => (
+          <img
+            key={i}
+            src={src}
+            alt={`Pre wedding ${i + 1}`}
+            className="w-32 h-32 object-cover border-4 border-solid border-yellow-700 shadow"
+            style={{ filter: "sepia(0.5)" }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/PreWeddingPhotos.tsx
+++ b/frontend/src/components/PreWeddingPhotos.tsx
@@ -26,14 +26,17 @@ export default function PreWeddingPhotos() {
       >
         📸 前撮り写真 📸
       </h2>
-      <div className="flex justify-center space-x-2">
+      <div className="font-bold underline text-xl">
+        ＠ｸﾞｯｹﾞﾝﾊｲﾑ邸
+      </div>
+      <div className=" justify-center space-x-2">
         {photos.map((src, i) => (
           <img
             key={i}
             src={src}
             alt={`Pre wedding ${i + 1}`}
-            className="w-32 h-32 object-cover border-4 border-solid border-yellow-700 shadow"
-            style={{ filter: "sepia(0.5)" }}
+            className="object-cover border-4 border-solid border-yellow-700 shadow"
+            style={{ filter: "sepia(0.3)" }}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- show new PreWeddingPhotos section on the invitation site
- include 3 example photos from `public`

## Testing
- `npm run lint -w frontend`
- `npm run build -w frontend`

------
https://chatgpt.com/codex/tasks/task_e_687279204438833184143d11510af4fb