### PR TITLE
Enhance RSVP form

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,10 +15,7 @@ function App() {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/rsvp`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: `${data.firstName} ${data.lastName}`,
-          attendance: data.attending
-        })
+        body: JSON.stringify(data)
       })
       if (!res.ok) throw new Error(await res.text())
       setRsvpStatus('success')

--- a/frontend/src/components/RSVPForm.tsx
+++ b/frontend/src/components/RSVPForm.tsx
@@ -4,10 +4,17 @@ import * as React from "react";
 import { useState } from "react";
 import { cn } from "../lib/utils";
 import { motion } from "framer-motion";
-export interface RSVPFormData {
-  firstName: string;
+export interface GuestInfo {
   lastName: string;
+  firstName: string;
+  lastNameKana: string;
+  firstNameKana: string;
+  allergy: string;
+  message: string;
+}
+export interface RSVPFormData {
   attending: string;
+  guests: GuestInfo[];
 }
 export interface RSVPFormProps {
   onSubmit?: (data: RSVPFormData) => void;
@@ -18,32 +25,76 @@ export default function RSVPForm({
   status = 'idle'
 }: RSVPFormProps) {
   const [formData, setFormData] = useState<RSVPFormData>({
-    firstName: '',
-    lastName: '',
-    attending: ''
+    attending: '',
+    guests: [
+      {
+        lastName: '',
+        firstName: '',
+        lastNameKana: '',
+        firstNameKana: '',
+        allergy: '',
+        message: ''
+      }
+    ]
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const handleInputChange = (field: keyof RSVPFormData, value: string) => {
+  const handleInputChange = (
+    index: number,
+    field: keyof GuestInfo,
+    value: string
+  ) => {
+    setFormData(prev => {
+      const guests = [...prev.guests];
+      guests[index] = { ...guests[index], [field]: value };
+      return { ...prev, guests };
+    });
+    const key = `${index}-${field}`;
+    if (errors[key]) {
+      setErrors(prev => {
+        const newErr = { ...prev };
+        delete newErr[key];
+        return newErr;
+      });
+    }
+  };
+  const handleAttendingChange = (value: string) => {
+    setFormData(prev => ({ ...prev, attending: value }));
+    if (errors.attending) {
+      setErrors(prev => ({ ...prev, attending: '' }));
+    }
+  };
+  const addGuest = () => {
     setFormData(prev => ({
       ...prev,
-      [field]: value
+      guests: [
+        ...prev.guests,
+        {
+          lastName: '',
+          firstName: '',
+          lastNameKana: '',
+          firstNameKana: '',
+          allergy: '',
+          message: ''
+        }
+      ]
     }));
-    // Clear error when user starts typing
-    if (errors[field]) {
-      setErrors(prev => ({
-        ...prev,
-        [field]: ''
-      }));
-    }
   };
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
-    if (!formData.firstName.trim()) {
-      newErrors.firstName = 'お名前（姓）を入力してください';
-    }
-    if (!formData.lastName.trim()) {
-      newErrors.lastName = 'お名前（名）を入力してください';
-    }
+    formData.guests.forEach((g, idx) => {
+      if (!g.lastName.trim()) {
+        newErrors[`${idx}-lastName`] = '姓を入力してください';
+      }
+      if (!g.firstName.trim()) {
+        newErrors[`${idx}-firstName`] = '名を入力してください';
+      }
+      if (!g.lastNameKana.trim()) {
+        newErrors[`${idx}-lastNameKana`] = '姓かなを入力してください';
+      }
+      if (!g.firstNameKana.trim()) {
+        newErrors[`${idx}-firstNameKana`] = '名かなを入力してください';
+      }
+    });
     if (!formData.attending) {
       newErrors.attending = 'ご出席の有無を選択してください';
     }
@@ -80,6 +131,8 @@ export default function RSVPForm({
         📝 出欠のご返信 📝
       </h2>
 
+<p className="mb-4 text-center">郵送でのご案内状に代わり　当招待状をお送りしております<br/>お手数ではございますが　出席情報のご登録をお願い申し上げます<br/><br/>また当日のお食事のご用意にあたり<br/>アレルギー等がある方は　アレルギー欄にご記入くださいますようお願い申し上げます</p>
+
       {/* Status Messages */}
       {status === 'loading' && <div className="text-center mb-6 p-4 bg-yellow-300 border-4 border-solid border-orange-500 rounded-lg" style={{
       boxShadow: '0 0 15px rgba(255,165,0,0.8)',
@@ -114,150 +167,147 @@ export default function RSVPForm({
             ❌ ｴﾗｰが発生しました。再度お試しください ❌
           </p>
         </div>}
+<form onSubmit={handleSubmit} noValidate>
+  {/* Attendance at top */}
+  <fieldset className="border-4 border-solid border-purple-500 p-4 rounded-lg mb-6 bg-gradient-to-br from-pink-100 to-purple-100" style={{
+    boxShadow: 'inset 0 0 15px rgba(255,255,255,0.8)'
+  }}>
+    <legend className="px-3 text-lg font-bold text-purple-800" style={{
+      textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
+      WebkitTextStroke: '0.5px black'
+    }}>
+      ご出席の有無*
+    </legend>
+    <div className="space-y-2">
+      {[{
+        value: 'Attending',
+        label: '✅ 出席します',
+        color: 'from-green-300 to-green-400'
+      }, {
+        value: 'Not Attending',
+        label: '❌ 欠席します',
+        color: 'from-red-300 to-red-400'
+      }].map(option => (
+        <label key={option.value} className={cn('flex items-center p-3 rounded-lg border-3 border-solid cursor-pointer transition-all duration-200', 'bg-gradient-to-r', option.color, formData.attending === option.value ? 'border-purple-600 shadow-lg' : 'border-gray-400 hover:border-purple-400', 'hover:scale-105')} style={{
+          boxShadow: formData.attending === option.value ? '0 0 15px rgba(128,0,128,0.6), inset 0 0 10px rgba(255,255,255,0.5)' : '0 0 5px rgba(0,0,0,0.2), inset 0 0 5px rgba(255,255,255,0.3)'
+        }}>
+          <input type="radio" name="attending" value={option.value} checked={formData.attending === option.value} onChange={e => handleAttendingChange(e.target.value)} className="mr-3 w-5 h-5 accent-purple-600" aria-describedby={errors.attending ? 'attending-error' : undefined} />
+          <span className="text-base font-bold text-gray-800" style={{
+            textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
+            WebkitTextStroke: '0.5px black'
+          }}>
+            {option.label}
+          </span>
+        </label>
+      ))}
+    </div>
+    {errors.attending && <p id="attending-error" className="mt-2 text-red-600 font-bold" style={{
+      textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
+      WebkitTextStroke: '0.5px black'
+    }} role="alert">
+      {errors.attending}
+    </p>}
+  </fieldset>
 
-      {/* RSVP Form */}
-      <form onSubmit={handleSubmit} noValidate>
-        <fieldset className="border-4 border-solid border-purple-500 p-4 rounded-lg bg-gradient-to-br from-pink-100 to-purple-100" style={{
-        boxShadow: 'inset 0 0 15px rgba(255,255,255,0.8)'
+  {formData.guests.map((guest, idx) => (
+    <fieldset key={idx} className="border-4 border-solid border-purple-500 p-4 rounded-lg mb-6 bg-gradient-to-br from-pink-100 to-purple-100" style={{
+      boxShadow: 'inset 0 0 15px rgba(255,255,255,0.8)'
+    }}>
+      <legend className="px-3 text-lg font-bold text-purple-800" style={{
+        textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
+        WebkitTextStroke: '0.5px black'
       }}>
-          <legend className="px-3 text-lg font-bold text-purple-800" style={{
-          textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-          WebkitTextStroke: '0.5px black'
-        }}>
-            お名前
-          </legend>
-
-          <div className="space-y-4">
-            {/* First Name */}
-            <div>
-              <label htmlFor="firstName" className="block text-base font-bold text-blue-700 mb-2" style={{
-              textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-              WebkitTextStroke: '0.5px black'
-            }}>
-                姓（例：山田）*
-              </label>
-              <input type="text" id="firstName" value={formData.firstName} onChange={e => handleInputChange('firstName', e.target.value)} className={cn("w-full p-3 text-base font-bold border-4 border-solid rounded-lg", "bg-white/90 text-purple-800", "focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75", "transition-all duration-200", errors.firstName ? "border-red-500" : "border-blue-400")} style={{
-              boxShadow: errors.firstName ? '0 0 10px rgba(255,0,0,0.5), inset 0 0 5px rgba(255,255,255,0.8)' : '0 0 10px rgba(0,100,255,0.3), inset 0 0 5px rgba(255,255,255,0.8)',
-              textShadow: '1px 1px 1px rgba(255,255,255,0.5)'
-            }} placeholder="姓を入力してください" aria-describedby={errors.firstName ? "firstName-error" : undefined} aria-invalid={!!errors.firstName} />
-              {errors.firstName && <p id="firstName-error" className="mt-1 text-red-600 font-bold" style={{
-              textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-              WebkitTextStroke: '0.5px black'
-            }} role="alert">
-                  {errors.firstName}
-                </p>}
-            </div>
-
-            {/* Last Name */}
-            <div>
-              <label htmlFor="lastName" className="block text-base font-bold text-blue-700 mb-2" style={{
-              textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-              WebkitTextStroke: '0.5px black'
-            }}>
-                名（例：花子）*
-              </label>
-              <input type="text" id="lastName" value={formData.lastName} onChange={e => handleInputChange('lastName', e.target.value)} className={cn("w-full p-3 text-base font-bold border-4 border-solid rounded-lg", "bg-white/90 text-purple-800", "focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75", "transition-all duration-200", errors.lastName ? "border-red-500" : "border-blue-400")} style={{
-              boxShadow: errors.lastName ? '0 0 10px rgba(255,0,0,0.5), inset 0 0 5px rgba(255,255,255,0.8)' : '0 0 10px rgba(0,100,255,0.3), inset 0 0 5px rgba(255,255,255,0.8)',
-              textShadow: '1px 1px 1px rgba(255,255,255,0.5)'
-            }} placeholder="名を入力してください" aria-describedby={errors.lastName ? "lastName-error" : undefined} aria-invalid={!!errors.lastName} />
-              {errors.lastName && <p id="lastName-error" className="mt-1 text-red-600 font-bold" style={{
-              textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-              WebkitTextStroke: '0.5px black'
-            }} role="alert">
-                  {errors.lastName}
-                </p>}
-            </div>
-
-            {/* Attendance */}
-            <fieldset>
-              <legend className="text-base font-bold text-blue-700 mb-3" style={{
-              textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-              WebkitTextStroke: '0.5px black'
-            }}>
-                ご出席の有無*
-              </legend>
-
-              <div className="space-y-2">
-                {[{
-                value: 'Attending',
-                label: '✅ 出席します',
-                color: 'from-green-300 to-green-400'
-              }, {
-                value: 'Maybe',
-                label: '🤔 未定',
-                color: 'from-yellow-300 to-yellow-400'
-              }, {
-                value: 'Not Attending',
-                label: '❌ 欠席します',
-                color: 'from-red-300 to-red-400'
-              }].map(option => <label key={option.value} className={cn("flex items-center p-3 rounded-lg border-3 border-solid cursor-pointer transition-all duration-200", "bg-gradient-to-r", option.color, formData.attending === option.value ? "border-purple-600 shadow-lg" : "border-gray-400 hover:border-purple-400", "hover:scale-105")} style={{
-                boxShadow: formData.attending === option.value ? '0 0 15px rgba(128,0,128,0.6), inset 0 0 10px rgba(255,255,255,0.5)' : '0 0 5px rgba(0,0,0,0.2), inset 0 0 5px rgba(255,255,255,0.3)'
-              }}>
-                    <input type="radio" name="attending" value={option.value} checked={formData.attending === option.value} onChange={e => handleInputChange('attending', e.target.value)} className="mr-3 w-5 h-5 accent-purple-600" aria-describedby={errors.attending ? "attending-error" : undefined} />
-                    <span className="text-base font-bold text-gray-800" style={{
-                  textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-                  WebkitTextStroke: '0.5px black'
-                }}>
-                      {option.label}
-                    </span>
-                  </label>)}
-              </div>
-
-              {errors.attending && <p id="attending-error" className="mt-2 text-red-600 font-bold" style={{
-              textShadow: '1px 1px 2px rgba(255,255,255,0.8)',
-              WebkitTextStroke: '0.5px black'
-            }} role="alert">
-                  {errors.attending}
-                </p>}
-            </fieldset>
-          </div>
-        </fieldset>
-
-        {/* Submit Button */}
-        <div className="text-center mt-6">
-          <motion.button type="submit" disabled={status === 'loading'} className={cn("px-8 py-4 text-xl font-black rounded-lg border-4 border-solid border-black", "bg-gradient-to-br from-yellow-400 via-orange-400 to-red-400", "text-white shadow-2xl", "focus:outline-none focus:ring-4 focus:ring-purple-400 focus:ring-opacity-75", "disabled:opacity-50 disabled:cursor-not-allowed", "transition-all duration-200")} style={{
-          textShadow: `
-                0 0 10px rgba(255,255,255,0.8)
-              `,
-          WebkitTextStroke: '1px black',
-          boxShadow: `
-                0 8px 0px #8B4513,
-                0 12px 20px rgba(0,0,0,0.4),
-                0 0 20px rgba(255,165,0,0.6),
-                inset 0 0 15px rgba(255,255,255,0.3)
-              `
-        }} whileHover={{
-          scale: 1.05,
-          boxShadow: `
-                0 8px 0px #8B4513,
-                0 12px 25px rgba(0,0,0,0.5),
-                0 0 25px rgba(255,165,0,0.8),
-                inset 0 0 20px rgba(255,255,255,0.4)
-              `
-        }} whileTap={{
-          scale: 0.95,
-          y: 4,
-          boxShadow: `
-                0 4px 0px #8B4513,
-                0 6px 15px rgba(0,0,0,0.4),
-                0 0 15px rgba(255,165,0,0.6),
-                inset 0 0 10px rgba(0,0,0,0.2)
-              `,
-          background: 'linear-gradient(135deg, #FF0000, #FF8C00, #FFD700)',
-          filter: 'invert(0.1)'
-        }} animate={{
-          boxShadow: status === 'loading' ? [`0 8px 0px #8B4513, 0 12px 20px rgba(0,0,0,0.4), 0 0 20px rgba(255,165,0,0.6)`, `0 8px 0px #8B4513, 0 12px 20px rgba(0,0,0,0.4), 0 0 30px rgba(255,165,0,0.8)`, `0 8px 0px #8B4513, 0 12px 20px rgba(0,0,0,0.4), 0 0 20px rgba(255,165,0,0.6)`] : undefined
-        }} transition={{
-          boxShadow: {
-            duration: 1,
-            repeat: status === 'loading' ? Infinity : 0,
-            ease: "easeInOut"
-          }
-        }}>
-            {status === 'loading' ? '⏳ 送信中...' : '🚀 送信する 🚀'}
-          </motion.button>
+        {idx === 0 ? 'お名前' : `お連れ様${idx}`}
+      </legend>
+      <div className="space-y-4">
+        <div>
+          <label htmlFor={`lastName-${idx}`} className="block text-base font-bold text-blue-700 mb-2" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }}>
+            姓*
+          </label>
+          <input type="text" id={`lastName-${idx}`} value={guest.lastName} onChange={e => handleInputChange(idx, 'lastName', e.target.value)} className={cn('w-full p-3 text-base font-bold border-4 border-solid rounded-lg', 'bg-white/90 text-purple-800', 'focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75', 'transition-all duration-200', errors[`${idx}-lastName`] ? 'border-red-500' : 'border-blue-400')} style={{
+            boxShadow: errors[`${idx}-lastName`] ? '0 0 10px rgba(255,0,0,0.5), inset 0 0 5px rgba(255,255,255,0.8)' : '0 0 10px rgba(0,100,255,0.3), inset 0 0 5px rgba(255,255,255,0.8)',
+            textShadow: '1px 1px 1px rgba(255,255,255,0.5)'
+          }} placeholder="姓を入力してください" aria-describedby={errors[`${idx}-lastName`] ? `lastName-${idx}-error` : undefined} aria-invalid={!!errors[`${idx}-lastName`]} />
+          {errors[`${idx}-lastName`] && <p id={`lastName-${idx}-error`} className="mt-1 text-red-600 font-bold" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }} role="alert">{errors[`${idx}-lastName`]}</p>}
         </div>
-      </form>
+        <div>
+          <label htmlFor={`firstName-${idx}`} className="block text-base font-bold text-blue-700 mb-2" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }}>
+            名*
+          </label>
+          <input type="text" id={`firstName-${idx}`} value={guest.firstName} onChange={e => handleInputChange(idx, 'firstName', e.target.value)} className={cn('w-full p-3 text-base font-bold border-4 border-solid rounded-lg', 'bg-white/90 text-purple-800', 'focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75', 'transition-all duration-200', errors[`${idx}-firstName`] ? 'border-red-500' : 'border-blue-400')} style={{
+            boxShadow: errors[`${idx}-firstName`] ? '0 0 10px rgba(255,0,0,0.5), inset 0 0 5px rgba(255,255,255,0.8)' : '0 0 10px rgba(0,100,255,0.3), inset 0 0 5px rgba(255,255,255,0.8)',
+            textShadow: '1px 1px 1px rgba(255,255,255,0.5)'
+          }} placeholder="名を入力してください" aria-describedby={errors[`${idx}-firstName`] ? `firstName-${idx}-error` : undefined} aria-invalid={!!errors[`${idx}-firstName`]} />
+          {errors[`${idx}-firstName`] && <p id={`firstName-${idx}-error`} className="mt-1 text-red-600 font-bold" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }} role="alert">{errors[`${idx}-firstName`]}</p>}
+        </div>
+        <div>
+          <label htmlFor={`lastNameKana-${idx}`} className="block text-base font-bold text-blue-700 mb-2" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }}>
+            姓かな*
+          </label>
+          <input type="text" id={`lastNameKana-${idx}`} value={guest.lastNameKana} onChange={e => handleInputChange(idx, 'lastNameKana', e.target.value)} className={cn('w-full p-3 text-base font-bold border-4 border-solid rounded-lg', 'bg-white/90 text-purple-800', 'focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75', 'transition-all duration-200', errors[`${idx}-lastNameKana`] ? 'border-red-500' : 'border-blue-400')} style={{
+            boxShadow: errors[`${idx}-lastNameKana`] ? '0 0 10px rgba(255,0,0,0.5), inset 0 0 5px rgba(255,255,255,0.8)' : '0 0 10px rgba(0,100,255,0.3), inset 0 0 5px rgba(255,255,255,0.8)',
+            textShadow: '1px 1px 1px rgba(255,255,255,0.5)'
+          }} placeholder="せいを入力してください" aria-describedby={errors[`${idx}-lastNameKana`] ? `lastNameKana-${idx}-error` : undefined} aria-invalid={!!errors[`${idx}-lastNameKana`]} />
+          {errors[`${idx}-lastNameKana`] && <p id={`lastNameKana-${idx}-error`} className="mt-1 text-red-600 font-bold" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }} role="alert">{errors[`${idx}-lastNameKana`]}</p>}
+        </div>
+        <div>
+          <label htmlFor={`firstNameKana-${idx}`} className="block text-base font-bold text-blue-700 mb-2" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }}>
+            名かな*
+          </label>
+          <input type="text" id={`firstNameKana-${idx}`} value={guest.firstNameKana} onChange={e => handleInputChange(idx, 'firstNameKana', e.target.value)} className={cn('w-full p-3 text-base font-bold border-4 border-solid rounded-lg', 'bg-white/90 text-purple-800', 'focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75', 'transition-all duration-200', errors[`${idx}-firstNameKana`] ? 'border-red-500' : 'border-blue-400')} style={{
+            boxShadow: errors[`${idx}-firstNameKana`] ? '0 0 10px rgba(255,0,0,0.5), inset 0 0 5px rgba(255,255,255,0.8)' : '0 0 10px rgba(0,100,255,0.3), inset 0 0 5px rgba(255,255,255,0.8)',
+            textShadow: '1px 1px 1px rgba(255,255,255,0.5)'
+          }} placeholder="めいを入力してください" aria-describedby={errors[`${idx}-firstNameKana`] ? `firstNameKana-${idx}-error` : undefined} aria-invalid={!!errors[`${idx}-firstNameKana`]} />
+          {errors[`${idx}-firstNameKana`] && <p id={`firstNameKana-${idx}-error`} className="mt-1 text-red-600 font-bold" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }} role="alert">{errors[`${idx}-firstNameKana`]}</p>}
+        </div>
+        <div>
+          <label htmlFor={`allergy-${idx}`} className="block text-base font-bold text-blue-700 mb-2" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }}>
+            アレルギー
+          </label>
+          <input type="text" id={`allergy-${idx}`} value={guest.allergy} onChange={e => handleInputChange(idx, 'allergy', e.target.value)} className={cn('w-full p-3 text-base font-bold border-4 border-solid rounded-lg', 'bg-white/90 text-purple-800', 'focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75', 'transition-all duration-200', 'border-blue-400')} placeholder="アレルギーがあればご記入ください" />
+        </div>
+        <div>
+          <label htmlFor={`message-${idx}`} className="block text-base font-bold text-blue-700 mb-2" style={{ textShadow: '1px 1px 2px rgba(255,255,255,0.8)', WebkitTextStroke: '0.5px black' }}>
+            メッセージ
+          </label>
+          <textarea id={`message-${idx}`} value={guest.message} onChange={e => handleInputChange(idx, 'message', e.target.value)} className={cn('w-full p-3 text-base font-bold border-4 border-solid rounded-lg', 'bg-white/90 text-purple-800', 'focus:outline-none focus:ring-4 focus:ring-yellow-400 focus:ring-opacity-75', 'transition-all duration-200', 'border-blue-400')} rows={3} placeholder="メッセージがあればご記入ください" />
+        </div>
+      </div>
+    </fieldset>
+  ))}
+
+  <div className="text-center mb-6">
+    <button type="button" onClick={addGuest} className="px-4 py-2 font-bold text-purple-800 border-4 border-purple-600 rounded-lg bg-white hover:bg-purple-100 transition">お連れ様を追加する</button>
+  </div>
+
+  <div className="text-center mt-6">
+    <motion.button type="submit" disabled={status === 'loading'} className={cn('px-8 py-4 text-xl font-black rounded-lg border-4 border-solid border-black', 'bg-gradient-to-br from-yellow-400 via-orange-400 to-red-400', 'text-white shadow-2xl', 'focus:outline-none focus:ring-4 focus:ring-purple-400 focus:ring-opacity-75', 'disabled:opacity-50 disabled:cursor-not-allowed', 'transition-all duration-200')} style={{
+      textShadow: '0 0 10px rgba(255,255,255,0.8)',
+      WebkitTextStroke: '1px black',
+      boxShadow: '0 8px 0px #8B4513, 0 12px 20px rgba(0,0,0,0.4), 0 0 20px rgba(255,165,0,0.6), inset 0 0 15px rgba(255,255,255,0.3)'
+    }} whileHover={{
+      scale: 1.05,
+      boxShadow: '0 8px 0px #8B4513, 0 12px 25px rgba(0,0,0,0.5), 0 0 25px rgba(255,165,0,0.8), inset 0 0 20px rgba(255,255,255,0.4)'
+    }} whileTap={{
+      scale: 0.95,
+      y: 4,
+      boxShadow: '0 4px 0px #8B4513, 0 6px 15px rgba(0,0,0,0.4), 0 0 15px rgba(255,165,0,0.6), inset 0 0 10px rgba(0,0,0,0.2)',
+      background: 'linear-gradient(135deg, #FF0000, #FF8C00, #FFD700)',
+      filter: 'invert(0.1)'
+    }} animate={{
+      boxShadow: status === 'loading' ? ['0 8px 0px #8B4513, 0 12px 20px rgba(0,0,0,0.4), 0 0 20px rgba(255,165,0,0.6)', '0 8px 0px #8B4513, 0 12px 20px rgba(0,0,0,0.4), 0 0 30px rgba(255,165,0,0.8)', '0 8px 0px #8B4513, 0 12px 20px rgba(0,0,0,0.4), 0 0 20px rgba(255,165,0,0.6)'] : undefined
+    }} transition={{
+      boxShadow: {
+        duration: 1,
+        repeat: status === 'loading' ? Infinity : 0,
+        ease: 'easeInOut'
+      }
+    }}>
+      {status === 'loading' ? '⏳ 送信中...' : '🚀 送信する 🚀'}
+    </motion.button>
+  </div>
+</form>
+
 
       {/* Help Text */}
       <p className="text-center mt-4 text-sm font-bold text-purple-600" style={{


### PR DESCRIPTION
## Summary
- add guest info fields and instructions
- allow multiple guests to be added
- send new RSVP payload shape

## Testing
- `npm run build -w frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68727e890f488331808a7492a1c99174