### PR TITLE
Add embedded map and fix rsvp form

### DIFF
--- a/SampleFrontend/src/components/generated/InvitationContent.tsx
+++ b/SampleFrontend/src/components/generated/InvitationContent.tsx
@@ -15,7 +15,7 @@ export default function InvitationContent({
   weddingDate = "令和6年10月31日（木）",
   weddingTime = "午後4時",
   venue = "東京グランドホール",
-  venueAddress = "東京都中央区銀座1-2-3",
+  venueAddress = "〒541-0051 大阪府大阪市中央区備後町２丁目５−８",
   decorativeImageUrl = "https://images.unsplash.com/photo-1519225421980-715cb0215aed?w=400&h=300&fit=crop"
 }: InvitationContentProps) {
   return <section className={cn("bg-white/90 border-8 border-double border-pink-600 p-6 rounded-lg", "shadow-2xl", "font-['Comic_Sans_MS',_cursive]")} style={{
@@ -172,6 +172,16 @@ export default function InvitationContent({
             }}>
                 📍 <strong>住所：</strong> {venueAddress}
               </p>
+              <div className="mt-4">
+                <iframe
+                  className="w-full h-64 border-4 border-solid border-green-700 rounded-lg"
+                  src="https://www.google.com/maps?q=%E3%80%92541-0051+%E5%A4%A7%E9%98%AA%E5%BA%9C%E5%A4%A7%E9%98%AA%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E5%82%99%E5%BE%8C%E7%94%BA%EF%BC%92%E4%B8%81%E7%9B%AE%EF%BC%95%E2%88%92%EF%BC%98+%E7%B6%BF%E6%A5%AD%E4%BC%9A%E9%A4%A8&output=embed"
+                  loading="lazy"
+                  referrerPolicy="no-referrer-when-downgrade"
+                  title="綿業会館 地図"
+                  allowFullScreen
+                ></iframe>
+              </div>
             </div>
 
             {/* Call to Action */}

--- a/frontend/src/components/InvitationContent.tsx
+++ b/frontend/src/components/InvitationContent.tsx
@@ -115,6 +115,16 @@ export default function InvitationContent({
                 }}>
                     📍 <strong>住所：</strong> {venueAddress}
                 </p>
+                <div className="mt-4">
+                    <iframe
+                        className="w-full h-64 border-4 border-solid border-green-700 rounded-lg"
+                        src="https://www.google.com/maps?q=%E3%80%92541-0051+%E5%A4%A7%E9%98%AA%E5%BA%9C%E5%A4%A7%E9%98%AA%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E5%82%99%E5%BE%8C%E7%94%BA%EF%BC%92%E4%B8%81%E7%9B%AE%EF%BC%95%E2%88%92%EF%BC%98+%E7%B6%BF%E6%A5%AD%E4%BC%9A%E9%A4%A8&output=embed"
+                        loading="lazy"
+                        referrerPolicy="no-referrer-when-downgrade"
+                        title="綿業会館 地図"
+                        allowFullScreen
+                    ></iframe>
+                </div>
             </div>
 
             {/* Call to Action */}

--- a/frontend/src/components/RSVPForm.tsx
+++ b/frontend/src/components/RSVPForm.tsx
@@ -296,7 +296,6 @@ export default function RSVPForm({
                         </div>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                             <div>
-                        <div>
                             <label htmlFor={`lastNameKana-${idx}`}
                                    className="block text-base font-bold text-blue-700 mb-2" style={{
                                 textShadow: '1px 1px 2px rgba(255,255,255,0.8)',


### PR DESCRIPTION
## Summary
- embed venue map in invitation details and sample invitation
- fix missing closing tag in RSVP form

## Testing
- `npm run lint -w frontend`
- `npm run build -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_687363e74ad48331812b23ba90257d60