### PR TITLE
Add visitor count API

### DIFF
--- a/frontend/src/components/HeaderBanner.tsx
+++ b/frontend/src/components/HeaderBanner.tsx
@@ -15,20 +15,17 @@ export default function HeaderBanner({
   const [visitCount, setVisitCount] = useState(0)
 
   useEffect(() => {
-    let count = 0
-    try {
-      // use 29 so the first display will be 30
-      count = parseInt(localStorage.getItem('visit-count') || '29', 10) + 1
-    } catch {
-      // ignore read errors
-      count = 30
+    const fetchCount = async () => {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/count`)
+        if (!res.ok) throw new Error('failed')
+        const data = await res.json()
+        setVisitCount(data.count ?? 0)
+      } catch {
+        // ignore errors
+      }
     }
-    try {
-      localStorage.setItem('visit-count', String(count))
-    } catch {
-      // ignore write errors
-    }
-    setVisitCount(count)
+    fetchCount()
   }, [])
 
   return (

--- a/infra/src/count.ts
+++ b/infra/src/count.ts
@@ -1,0 +1,16 @@
+import { APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+
+const client = new DynamoDBClient({});
+const TABLE_NAME = process.env.TABLE_NAME as string;
+
+export const handler = async (): Promise<APIGatewayProxyResultV2> => {
+  const result = await client.send(
+    new ScanCommand({ TableName: TABLE_NAME, Select: 'COUNT' })
+  );
+  const count = result.Count ?? 0;
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ count }),
+  };
+};


### PR DESCRIPTION
## Summary
- implement Lambda to count DynamoDB items
- expose `/count` endpoint and allow GET requests via API Gateway
- fetch real count in header banner instead of using localStorage

## Testing
- `npm test -w infra`

------
https://chatgpt.com/codex/tasks/task_e_687a2aeeb60c83319f98c9438de1e7f1