### PR TITLE
Add visitor count tracking

### DIFF
--- a/frontend/src/components/HeaderBanner.tsx
+++ b/frontend/src/components/HeaderBanner.tsx
@@ -15,7 +15,13 @@ export default function HeaderBanner({
   const [visitCount, setVisitCount] = useState(0)
 
   useEffect(() => {
-    const fetchCount = async () => {
+    const recordAndFetch = async () => {
+      try {
+        await fetch(`${import.meta.env.VITE_API_URL}/access`, { method: 'POST' })
+      } catch {
+        // ignore errors
+      }
+
       try {
         const res = await fetch(`${import.meta.env.VITE_API_URL}/count`)
         if (!res.ok) throw new Error('failed')
@@ -25,7 +31,8 @@ export default function HeaderBanner({
         // ignore errors
       }
     }
-    fetchCount()
+
+    recordAndFetch()
   }, [])
 
   return (

--- a/infra/src/access.ts
+++ b/infra/src/access.ts
@@ -1,0 +1,23 @@
+import { APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { randomUUID } from 'crypto';
+
+const client = new DynamoDBClient({});
+const TABLE_NAME = process.env.TABLE_NAME as string;
+
+export const handler = async (): Promise<APIGatewayProxyResultV2> => {
+  await client.send(
+    new PutItemCommand({
+      TableName: TABLE_NAME,
+      Item: {
+        id: { S: randomUUID() },
+        timestamp: { N: Date.now().toString() },
+      },
+    })
+  );
+
+  return {
+    statusCode: 200,
+    body: 'ok',
+  };
+};


### PR DESCRIPTION
## Summary
- create new `AccessCountTable` DynamoDB table
- add lambda to record each page access
- expose `/access` endpoint and count accesses via `/count`
- update frontend banner to hit the new endpoint on load

## Testing
- `npm run build -w infra`
- `npm run build -w frontend`
- `npm test -w infra`


------
https://chatgpt.com/codex/tasks/task_e_687d96046914833189eb6dc70465274b