### PR TITLE
Add visit count to RSVP payload

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { cn } from './lib/utils'
 
 function App() {
   const [rsvpStatus, setRsvpStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [visitCount, setVisitCount] = useState(0)
 
   const handleRSVPSubmit = async (data: RSVPFormData) => {
     setRsvpStatus('loading')
@@ -15,7 +16,7 @@ function App() {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/rsvp`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data)
+        body: JSON.stringify({ ...data, visitCount })
       })
       if (!res.ok) throw new Error(await res.text())
       setRsvpStatus('success')
@@ -44,7 +45,7 @@ function App() {
         `
       }}
     >
-      <HeaderBanner />
+      <HeaderBanner onVisitCountChange={setVisitCount} />
       <main
         className="table w-full max-w-[800px] mx-auto bg-white/90 border-8 border-double border-purple-600 shadow-2xl"
         style={{

--- a/frontend/src/components/HeaderBanner.tsx
+++ b/frontend/src/components/HeaderBanner.tsx
@@ -6,11 +6,13 @@ import { useEffect, useState } from 'react'
 export interface HeaderBannerProps {
   weddingDate?: string
   coupleNames?: string
+  onVisitCountChange?: (count: number) => void
 }
 
 export default function HeaderBanner({
   weddingDate = '令和7年9月27日（土）',
   coupleNames = '誠也 ＆ 有紀',
+  onVisitCountChange,
 }: HeaderBannerProps) {
   const [visitCount, setVisitCount] = useState(0)
 
@@ -26,14 +28,16 @@ export default function HeaderBanner({
         const res = await fetch(`${import.meta.env.VITE_API_URL}/count`)
         if (!res.ok) throw new Error('failed')
         const data = await res.json()
-        setVisitCount(data.count ?? 0)
+        const count = data.count ?? 0
+        setVisitCount(count)
+        if (onVisitCountChange) onVisitCountChange(count)
       } catch {
         // ignore errors
       }
     }
 
     recordAndFetch()
-  }, [])
+  }, [onVisitCountChange])
 
   return (
     <header

--- a/frontend/src/components/RSVPForm.tsx
+++ b/frontend/src/components/RSVPForm.tsx
@@ -420,7 +420,7 @@ export default function RSVPForm({
                             textShadow: '2px 2px 4px rgba(0,0,0,0.5)',
                             WebkitTextStroke: '1px black'
                         }}>
-                            ❌ 入力内容に誤りがあります　ご確認ください ❌
+                            ❌ 入力内容に誤りがあります ご確認ください ❌
                         </p>
                     </motion.div>
                 )}
@@ -462,7 +462,7 @@ export default function RSVPForm({
                             textShadow: '2px 2px 4px rgba(0,0,0,0.5)',
                             WebkitTextStroke: '1px black'
                         }}>
-                            ❌ ｴﾗｰが発生しました　再度お試しください ❌
+                            ❌ ｴﾗｰが発生しました 再度お試しください ❌
                         </p>
                     </div>}
             </div>


### PR DESCRIPTION
## Summary
- share visitor count from `HeaderBanner` via callback
- send this count as `visitCount` when submitting an RSVP
- fix lint warnings by removing irregular whitespace

## Testing
- `npm run lint -w frontend`
- `npm run build -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_687db60f0cd08331a90bc34ed64efad7